### PR TITLE
feat: add image block

### DIFF
--- a/src/components/EditableForm.vue
+++ b/src/components/EditableForm.vue
@@ -4,7 +4,9 @@
   import BaseSpacer from './BaseSpacer.vue'
   import IconBin from './IconBin.vue'
   import IconDrag from './IconDrag.vue'
+  import IconPlus from './IconPlus.vue'
   import EditableBlock from './EditableBlock.vue'
+  import ImageBlock from './ImageBlock.vue'
   import { useBlocks } from '../composables/useBlocks.js'
 
   const drag = ref(false)
@@ -21,6 +23,7 @@
     updateBlock,
     updateTitle,
     addBlockAfter,
+    addImageBlockAfter,
     deleteBlock,
   } = useBlocks()
 
@@ -32,6 +35,23 @@
         el.focus()
       }
     })
+  }
+
+  function addImageBlock(index) {
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.accept = 'image/png, image/jpeg'
+    input.onchange = (e) => {
+      const file = e.target.files[0]
+      const text = file.name
+      const reader = new FileReader()
+      reader.onload = (readerEvent) => {
+        const content = readerEvent.target.result
+        addImageBlockAfter(index, content, text)
+      }
+      reader.readAsDataURL(file)
+    }
+    input.click()
   }
 </script>
 
@@ -70,19 +90,27 @@
             flex
             text-gray-400
             opacity-0
-            group-hover:opacity-100
-            group-focus:opacity-100
-            focus-within:opacity-100
+            group-hover:opacity-70
+            group-focus:opacity-70
+            focus-within:opacity-70
           "
         >
           <button @click="deleteBlock(element.id)">
             <IconBin />
           </button>
+          <button @click="addImageBlock(index)">
+            <IconPlus />
+          </button>
           <div data-action="handle" class="cursor-move">
             <IconDrag />
           </div>
         </div>
-        <EditableBlock
+        <ImageBlock v-if="element.tag === 'img'"
+          :id="element.id"
+          :content="element.content"
+          :text="element.text"
+        />
+        <EditableBlock v-else
           :id="element.id"
           :tag="element.tag"
           :html="element.html"

--- a/src/components/IconBin.vue
+++ b/src/components/IconBin.vue
@@ -7,9 +7,9 @@
     stroke="currentColor"
   >
     <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="{2}"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
       d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
     />
   </svg>

--- a/src/components/IconPlus.vue
+++ b/src/components/IconPlus.vue
@@ -10,7 +10,7 @@
       stroke-linecap="round"
       stroke-linejoin="round"
       stroke-width="2"
-      d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+      d="M12 3 L12 21 M3 12 L21 12"
     />
   </svg>
 </template>

--- a/src/components/ImageBlock.vue
+++ b/src/components/ImageBlock.vue
@@ -1,0 +1,28 @@
+<script>
+</script>
+
+<script setup>
+  import { defineProps } from 'vue'
+
+  const props = defineProps({
+    id: {
+      type: String,
+      default: '',
+    },
+    content: {
+      type: String,
+      default: '',
+    },
+    text: {
+      type: String,
+      default: '',
+    },
+  })
+</script>
+
+<template>
+  <img :id="id" :src="props.content" :alt="props.text" />
+</template>
+
+<style scoped>
+</style>

--- a/src/composables/useBlocks.js
+++ b/src/composables/useBlocks.js
@@ -48,6 +48,12 @@ export function useBlocks() {
     return newBlock
   }
 
+  function addImageBlockAfter(index, content, text) {
+    const newBlock = { id: v4(), content: content, text, tag: 'img' }
+    blocks.value.splice(index + 1, 0, newBlock)
+    return newBlock
+  }
+
   function deleteBlock(id) {
     blocks.value = blocks.value.filter((block) => block.id !== id)
   }
@@ -85,6 +91,7 @@ export function useBlocks() {
     title: readonly(title),
     deleteBlock,
     addBlockAfter,
+    addImageBlockAfter,
     updateTag,
     updateTitle,
     updateBlock,


### PR DESCRIPTION
fix svg-attributes on svg icons
add image block on + with file picker

sorry, I don't know what second point on acceptance-criteria means (It displays the options "Image")

currently there is no special image centering of size limitation. do we need one ?

saving works without any changes - well done: JSON.stringify :-)