### PR TITLE
fix: #5

### DIFF
--- a/src/components/EditableBlock.vue
+++ b/src/components/EditableBlock.vue
@@ -43,6 +43,7 @@
   const emit = defineEmits([
     'change-content',
     'enter-pressed',
+    'delete-block',
     'arrow-up',
     'arrow-down',
   ])
@@ -58,6 +59,7 @@
   function keyDown(event) {
     const ARROW_UP = 38
     const ARROW_DOWN = 40
+    const BACKSPACE = 8
 
     if (event.keyCode === ARROW_UP) {
       event.preventDefault()
@@ -65,6 +67,12 @@
     } else if (content.value.trim() !== '' && event.keyCode === ARROW_DOWN) {
       event.preventDefault()
       emit('arrow-down')
+    } else if (event.keyCode === BACKSPACE) {
+      const sel = window.getSelection()
+      if (sel && sel.anchorOffset === 0 && sel.focusOffset === 0) {
+        event.preventDefault()
+        emit('delete-block')
+      }
     }
   }
 

--- a/src/components/EditableForm.vue
+++ b/src/components/EditableForm.vue
@@ -27,14 +27,9 @@
     deleteBlock,
   } = useBlocks()
 
-  function addAndFocusOnBlock(index) {
+  async function addAndFocusOnBlock(index) {
     const newBlock = addBlockAfter(index)
-    nextTick(() => {
-      const el = document.getElementById(newBlock.id)
-      if (el) {
-        el.focus()
-      }
-    })
+    await focusBlock(newBlock.id)
   }
 
   function addImageBlock(index) {
@@ -64,6 +59,56 @@
     if (domElement) {
       domElement.focus()
     }
+  }
+
+  /*
+     a, b, c    remove empty b        =>  a,   c
+     a, b, c    remove b with content =>  a+b, c
+  */
+  async function deleteAndFocusPreviousBlock(id, index) {
+    const prevBlock = getBlockByIndex(index - 1)
+    if (prevBlock) {
+      await focusBlock(prevBlock.id)
+      const currentBlock = getBlockByIndex(index)
+      const currentContent = currentBlock.html
+      const prevContent = prevBlock.html
+      const prevId = prevBlock.id
+      if (currentContent) {
+        // updateBlock with rerendering (true)
+
+        // unfortunately that rerendering makes trouble:
+        // 'Uncaught TypeError: Cannot read property 'innerText' of null'
+        // vue-contenteditable npm package
+        updateBlock(prevBlock.id, prevContent + currentContent, true)
+      }
+      deleteBlock(id)
+      focusBlock(prevId, prevContent.length)
+    }
+  }
+
+  function getBlockByIndex(index) {
+    if (index < 0 || index >= blocks.value.length) {
+      return null
+    }
+    return blocks.value[index]
+  }
+
+  function setCaret(id, caretIndex) {
+    const el = document.getElementById(id)
+    const sel = window.getSelection()
+    sel.collapse(el.lastChild, caretIndex)
+  }
+
+  function focusBlock(id, pos = -1) {
+    return nextTick(() => {
+      const domElement = document.getElementById(id)
+      if (domElement) {
+        domElement.focus()
+        if (pos >= 0) {
+          setCaret(id, pos)
+        }
+      }
+    })
   }
 </script>
 
@@ -126,6 +171,7 @@
         <EditableBlock
           v-else
           :id="element.id"
+          :key="element.version"
           :tag="element.tag"
           :html="element.html"
           placeholder="Type to add block"
@@ -134,6 +180,7 @@
           @arrowDown="setFocusOn(index + 1)"
           @changeContent="(html) => updateBlock(element.id, html)"
           @enterPressed="addAndFocusOnBlock(index)"
+          @deleteBlock="deleteAndFocusPreviousBlock(element.id, index)"
         />
       </div>
     </template>

--- a/src/composables/useBlocks.js
+++ b/src/composables/useBlocks.js
@@ -9,7 +9,7 @@ import {
 const BLOCKS = 'blocks'
 const TITLE = 'title'
 
-const createInitialBlock = () => ({ id: v4(), html: '', tag: 'p' })
+const createInitialBlock = () => ({ id: v4(), html: '', tag: 'p', version: 1 })
 const title = ref('')
 
 const blocks = ref([])
@@ -25,9 +25,12 @@ if (localStorageHas(TITLE)) {
 }
 
 export function useBlocks() {
-  function updateBlock(id, html) {
+  function updateBlock(id, html, rerender = false) {
     const block = blocks.value.find((block) => block.id === id)
     block.html = html
+    if (rerender) {
+      block.version++
+    }
   }
 
   function updateTag(id, tag) {


### PR DESCRIPTION
fix: #5 
delete block with 'backspace' and the caret is on the first position.

concat previous block and deleted block

updateBlock does not rerender the new content, so I introduced a ``.version`` for each block that is the ``:key`` for vue rendering. and on changing that ``version`` causes a rerendering => we see the new content in the browser.

but unfortunately than there is an error in the vue-contenteditable npm package.
![rerender block](https://user-images.githubusercontent.com/1595098/129481900-10a2871e-aa4e-4098-b484-0fafa24216b4.png)

That delete-feature is working but that error in dev-tools isn't good. Do you have an idea?

