### PR TITLE
feat: split current line at caret

### DIFF
--- a/src/components/EditableForm.vue
+++ b/src/components/EditableForm.vue
@@ -27,9 +27,38 @@
     deleteBlock,
   } = useBlocks()
 
+  /*
+    split the current line at the caret position and creates a new block below
+
+          hello w|orld   
+
+          hello w
+          orld
+
+    on a range-selection (two caret position) split up in left and right part          
+
+          hello w|or|ld
+
+          hello w
+          ld
+  */
   async function addAndFocusOnBlock(index) {
-    const newBlock = addBlockAfter(index)
-    await focusBlock(newBlock.id)
+    const currentBlock = getBlockByIndex(index)
+    if (currentBlock) {
+      const sel = window.getSelection()
+      if (sel) {
+        const value = currentBlock.html
+        const idxLeft = Math.min(sel.anchorOffset, sel.focusOffset)
+        const idxRight = Math.max(sel.anchorOffset, sel.focusOffset)
+        const leftValue = value.substring(0, idxLeft).trim()
+        const rightValue = value.substring(idxRight).trim()
+        currentBlock.html = leftValue
+        const newBlock = addBlockAfter(index)
+        newBlock.html = rightValue
+
+        await focusBlock(newBlock.id)
+      }
+    }
   }
 
   function addImageBlock(index) {

--- a/src/components/EditableForm.vue
+++ b/src/components/EditableForm.vue
@@ -52,9 +52,9 @@
         const idxRight = Math.max(sel.anchorOffset, sel.focusOffset)
         const leftValue = value.substring(0, idxLeft).trim()
         const rightValue = value.substring(idxRight).trim()
-        currentBlock.html = leftValue
-        const newBlock = addBlockAfter(index)
-        newBlock.html = rightValue
+
+        updateBlock(currentBlock.id, leftValue)
+        const newBlock = addBlockAfter(index, rightValue)
 
         await focusBlock(newBlock.id)
       }

--- a/src/components/ImageBlock.vue
+++ b/src/components/ImageBlock.vue
@@ -22,7 +22,6 @@
     const ARROW_UP = 38
     const ARROW_DOWN = 40
     const BACKSPACE = 8
-    let key = ''
 
     if (event.keyCode === ARROW_UP) {
       emit('arrow-up')

--- a/src/composables/useBlocks.js
+++ b/src/composables/useBlocks.js
@@ -42,8 +42,9 @@ export function useBlocks() {
     title.value = html
   }
 
-  function addBlockAfter(index) {
+  function addBlockAfter(index, html = '') {
     const newBlock = createInitialBlock()
+    newBlock.html = html
     blocks.value.splice(index + 1, 0, newBlock)
     return newBlock
   }


### PR DESCRIPTION
fix: #24

if a range is selected, that that range will be ignored. (default behaviour on contenteditable - and similar to notion.so)
